### PR TITLE
Add mnossUpdateToRuben flow for MNOSS updates to Ruben system

### DIFF
--- a/event-from-am-connect.xml
+++ b/event-from-am-connect.xml
@@ -39,4 +39,35 @@ http://www.mulesoft.org/schema/mule/kinesis-logger http://www.mulesoft.org/schem
 
         <error-handler ref="globalErrorHandler"/>
     </flow>
+
+    <flow name="mnossUpdateToRuben">
+        <sqs:receivemessages config-ref="Amazon_Sqs_Configuration_AmConnect_MNOSS"
+                             queueUrl="${aws.sqs.queueUrl.amConnectRubenMnoss}"
+                             preserveMessages="true"
+                             visibilityTimeout="${aws.sqs.visibilityTimeout.short}"/>
+
+        <set-variable variableName="flowName" value="mnossUpdateToRuben"/>
+        <set-variable variableName="flowSource" value="amConnect"/>
+        <set-variable variableName="flowDestination" value="ruben"/>
+        <set-variable variableName="queueUrl" value="${aws.sqs.queueUrl.amConnectRubenMnoss}"/>
+        <set-variable variableName="alertIntegration" value="MNOSS updates from AMConnect to Ruben in ${env}"/>
+        <set-variable variableName="receiptHandle" value="#[attributes.'sqs.message.receipt.handle']"/>
+        <set-payload value="#[output json --- read(payload, 'json')]"/>
+        <kinesis-logger:put-record-async level="INFO" message="#[output json --- payload]" category="com.polestar.source-events.mnossUpdateToRuben.#1" source="#[vars.flowSource]" destination="#[vars.flowDestination]" transactionId="#[vars.transactionId]" config-ref="Kinesis_Logger_Config"/>
+
+        <set-payload value="#[${file::dwl/amconnect/mnoss-updates-to-salesforce.dwl}]"/>
+        <kinesis-logger:put-record-async level="INFO" message="#[output json --- payload]" category="com.polestar.source-events.mnossUpdateToRuben.#2" source="#[vars.flowSource]" destination="#[vars.flowDestination]" transactionId="#[vars.transactionId]" config-ref="Kinesis_Logger_Config"/>
+
+        <http:request config-ref="Mule_Salesforce_Oauth_API_Config" path="/polestar-product/vin/{vin}" method="PATCH">
+            <http:headers>#[{'transaction-id': vars.transactionId}]</http:headers>
+            <http:uri-params>#[{'vin': payload.vin}]</http:uri-params>
+        </http:request>
+        <kinesis-logger:put-record-async level="INFO" message="MNOSS Updates sent to Ruben" category="com.polestar.source-events.mnossUpdateToRuben.#3" source="#[vars.flowSource]" destination="#[vars.flowDestination]" transactionId="#[vars.transactionId]" config-ref="Kinesis_Logger_Config"/>
+
+        <sqs:delete-message config-ref="Amazon_Sqs_Configuration_AmConnect_MNOSS"
+                            receiptHandle="#[vars.receiptHandle]"
+                            queueUrl="#[vars.queueUrl]"/>
+
+        <error-handler ref="globalErrorHandler"/>
+    </flow>
 </mule>


### PR DESCRIPTION
## Summary
This PR adds a new Mule flow `mnossUpdateToRuben` to handle MNOSS updates from AMConnect to Ruben system.

## Changes Made
- ✅ Created new flow `mnossUpdateToRuben` based on existing `mnossUpdateToSalesforce` flow
- ✅ Updated SQS queue configuration to use `${aws.sqs.queueUrl.amConnectRubenMnoss}` (resolves to `mule-dev-mnoss-ruben-amConnect`)
- ✅ Modified flow variables:
  - `flowName`: Set to "mnossUpdateToRuben"
  - `flowDestination`: Changed from "salesforce" to "ruben"
  - `alertIntegration`: Updated message to reference Ruben destination
- ✅ Updated Kinesis logging categories for proper tracking
- ✅ Maintained same processing logic, error handling, and message cleanup

## Flow Architecture
The new flow follows the same pattern as the existing Salesforce flow:
1. **SQS Message Reception** - Receives messages from the new Ruben-specific queue
2. **Variable Setup** - Sets flow metadata and tracking variables
3. **Payload Processing** - Processes JSON payload with logging
4. **Data Transformation** - Applies DataWeave transformation (currently uses same file)
5. **HTTP Request** - Makes PATCH request to API endpoint
6. **Cleanup** - Deletes processed message from SQS queue
7. **Error Handling** - Uses global error handler

## Configuration Requirements
Please ensure the following property is added to your environment configuration:
```properties
aws.sqs.queueUrl.amConnectRubenMnoss=mule-dev-mnoss-ruben-amConnect
```

## Testing Notes
- Both flows are now available in the same Mule application
- Each flow operates independently with its own SQS queue
- Logging is properly segregated with different category names
- Error handling remains consistent across both flows

## Future Considerations
- Consider creating a separate DataWeave transformation file for Ruben-specific processing if needed
- May need different HTTP configuration if Ruben endpoint differs from Salesforce configuration