### PR TITLE
Add mnossUpdateToAnand flow with SQS queue integration

### DIFF
--- a/event-from-am-connect.xml
+++ b/event-from-am-connect.xml
@@ -39,4 +39,35 @@ http://www.mulesoft.org/schema/mule/kinesis-logger http://www.mulesoft.org/schem
 
         <error-handler ref="globalErrorHandler"/>
     </flow>
+
+    <flow name="mnossUpdateToAnand">
+        <sqs:receivemessages config-ref="Amazon_Sqs_Configuration_AmConnect_MNOSS"
+                             queueUrl="${aws.sqs.queueUrl.amConnectAnandMnoss}"
+                             preserveMessages="true"
+                             visibilityTimeout="${aws.sqs.visibilityTimeout.short}"/>
+
+        <set-variable variableName="flowName" value="mnossUpdateToAnand"/>
+        <set-variable variableName="flowSource" value="amConnect"/>
+        <set-variable variableName="flowDestination" value="anand"/>
+        <set-variable variableName="queueUrl" value="${aws.sqs.queueUrl.amConnectAnandMnoss}"/>
+        <set-variable variableName="alertIntegration" value="MNOSS updates from AMConnect to Anand in ${env}"/>
+        <set-variable variableName="receiptHandle" value="#[attributes.'sqs.message.receipt.handle']"/>
+        <set-payload value="#[output json --- read(payload, 'json')]"/>
+        <kinesis-logger:put-record-async level="INFO" message="#[output json --- payload]" category="com.polestar.source-events.mnossUpdateToAnand.#1" source="#[vars.flowSource]" destination="#[vars.flowDestination]" transactionId="#[vars.transactionId]" config-ref="Kinesis_Logger_Config"/>
+
+        <set-payload value="#[${file::dwl/amconnect/mnoss-updates-to-salesforce.dwl}]"/>
+        <kinesis-logger:put-record-async level="INFO" message="#[output json --- payload]" category="com.polestar.source-events.mnossUpdateToAnand.#2" source="#[vars.flowSource]" destination="#[vars.flowDestination]" transactionId="#[vars.transactionId]" config-ref="Kinesis_Logger_Config"/>
+
+        <http:request config-ref="Mule_Salesforce_Oauth_API_Config" path="/polestar-product/vin/{vin}" method="PATCH">
+            <http:headers>#[{'transaction-id': vars.transactionId}]</http:headers>
+            <http:uri-params>#[{'vin': payload.vin}]</http:uri-params>
+        </http:request>
+        <kinesis-logger:put-record-async level="INFO" message="MNOSS Updates sent to Anand" category="com.polestar.source-events.mnossUpdateToAnand.#3" source="#[vars.flowSource]" destination="#[vars.flowDestination]" transactionId="#[vars.transactionId]" config-ref="Kinesis_Logger_Config"/>
+
+        <sqs:delete-message config-ref="Amazon_Sqs_Configuration_AmConnect_MNOSS"
+                            receiptHandle="#[vars.receiptHandle]"
+                            queueUrl="#[vars.queueUrl]"/>
+
+        <error-handler ref="globalErrorHandler"/>
+    </flow>
 </mule>


### PR DESCRIPTION
## Summary
This PR adds a new MuleSoft flow `mnossUpdateToAnand` based on the existing `mnossUpdateToSalesforce` flow.

## Changes Made
- **New Flow**: Created `mnossUpdateToAnand` flow in `event-from-am-connect.xml`
- **SQS Configuration**: Updated to use `amConnectAnandMnoss` queue (configured as `mule-dev-mnoss-anand-amConnect`)
- **Flow Variables**: Updated destination from "salesforce" to "anand"
- **Logging**: Updated Kinesis logger categories and messages to reflect new destination

## Flow Analysis
The new flow follows the same pattern as `mnossUpdateToSalesforce`:

1. **SQS Message Reception**: Receives messages from the specified SQS queue
2. **Variable Setup**: Sets flow metadata (name, source, destination, etc.)
3. **Data Processing**: Uses the same DataWeave transformation file
4. **HTTP Request**: Makes PATCH request to the same endpoint
5. **Logging**: Logs at each step using Kinesis logger
6. **Message Cleanup**: Deletes processed message from SQS queue
7. **Error Handling**: Uses global error handler

## Configuration Requirements
Please ensure the following configuration is added to your properties files:
```
aws.sqs.queueUrl.amConnectAnandMnoss=mule-dev-mnoss-anand-amConnect
```

## Testing
- [ ] Verify SQS queue configuration
- [ ] Test message processing
- [ ] Verify logging output
- [ ] Test error handling scenarios